### PR TITLE
fixed testing to emit correct rc

### DIFF
--- a/jcl/src/tester
+++ b/jcl/src/tester
@@ -22,6 +22,7 @@ echo "testing kind = " $kind
 
 export myRC=0
 export tmp01=/tmp/$(date +%Y%m%d%H%M%S).$$.mapajcl01
+export tmp02=/tmp/$(date +%Y%m%d%H%M%S).$$.mapajcl02
 if [ "$1" = "all" ]
 then
   ls -Al testdata/test0*.$sufx | awk '{print $9}' > $tmp01
@@ -29,16 +30,10 @@ else
   ls -Al testdata/test$1.$sufx | awk '{print $9}' > $tmp01
 fi
 
-#if [ "$2" = "pp" ]
-#then
-#  export kind="JCLPP"
-#else
-#  export kind="JCL"
-#fi
-
 while read line
 do
-  java -cp ./class:.:./antlr-4.7.2-complete.jar org.antlr.v4.gui.TestRig $kind startRule -tokens < $line | grep -v '^\['
+  java -cp ./class:.:./antlr-4.7.2-complete.jar org.antlr.v4.gui.TestRig $kind startRule -tokens < $line 1>/dev/null 2>$tmp02
+  grep -v '^\[' $tmp02
   if [ "$?" -eq 0 ]
   then
     export myRC=12
@@ -48,13 +43,15 @@ do
   export filePart=${line: -8}
   export numPart=${filePart:0:4}
   java -cp ./class:.:./antlr-4.7.2-complete.jar org.antlr.v4.gui.TestRig $kind startRule -tree < $line | ./src/treeCount -vruleName=test$numPart -vruleType=$kind
-  if [ $? > $myRC ]
+  export myRC1=$?
+  if [ "$myRC1" -gt "$myRC" ]
   then
-    export myRC=$?
+    export myRC=$myRC1
   fi
 done < $tmp01
 
 rm $tmp01
+rm $tmp02
 
 exit $myRC
 

--- a/jcl/src/treeCount
+++ b/jcl/src/treeCount
@@ -44,7 +44,7 @@ for (i = 1; i <= nbStrings; i++) {
 
 if (rc == 0) print ruleName " OK";
 
-EXIT rc
+exit rc
 }
 
 function countThese(mString) {


### PR DESCRIPTION
The tester and treeCount scripts now emit the correct return codes to make
make fail when testing indicates failure.  My bash-fu was lacking.