### PR TITLE
When getting the copybook filename, remove character " from COPY statement literal

### DIFF
--- a/cobol/src/CopyStatement.java
+++ b/cobol/src/CopyStatement.java
@@ -242,10 +242,14 @@ public class CopyStatement extends CopyReplaceParent implements CompilerDirectin
 
 	public String getCopyFile() {
 		String copyFile = this.getCopyFileRaw();
+		String delimiterChar = null;
 
-		if (copyFile.indexOf("'") != -1) {
+		if (copyFile.contains("'")) delimiterChar = "'";
+		if (copyFile.contains("\"")) delimiterChar = "\"";
+
+		if (delimiterChar != null) {
 			copyFile = 
-				copyFile.substring(copyFile.indexOf("'") + 1, copyFile.lastIndexOf("'"));
+				copyFile.substring(copyFile.indexOf(delimiterChar) + 1, copyFile.lastIndexOf(delimiterChar));
 		}
 
 		return copyFile;


### PR DESCRIPTION
When the COBOL source has a COPY statement such as `COPY "MYCPY".`, the function `getCopyFile` was returning `copyFile = "\"MYCPY\""`.

The function already removed the ' character from the string, so I made a change so that the function also removes the character "

I ran the tests with testList90, testList91 and nistList and there were no errors.

This is my first contribution, I'm open to any inputs!